### PR TITLE
FFS-2151: Endre Page<> response i integration-service

### DIFF
--- a/src/main/kotlin/no/novari/flyt/integration/api/IntegrationController.kt
+++ b/src/main/kotlin/no/novari/flyt/integration/api/IntegrationController.kt
@@ -2,6 +2,7 @@ package no.novari.flyt.integration.api
 
 import jakarta.validation.Valid
 import no.novari.flyt.integration.api.dto.IntegrationDto
+import no.novari.flyt.integration.api.dto.IntegrationPageResponse
 import no.novari.flyt.integration.api.dto.IntegrationPatchDto
 import no.novari.flyt.integration.api.dto.IntegrationPostDto
 import no.novari.flyt.integration.application.IntegrationService
@@ -11,9 +12,7 @@ import no.novari.flyt.integration.web.ForbiddenWithoutBodyException
 import no.novari.flyt.integration.web.NotFoundException
 import no.novari.flyt.webresourceserver.UrlPaths.INTERNAL_API
 import no.novari.flyt.webresourceserver.security.user.UserAuthorizationService
-import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
@@ -37,20 +36,27 @@ class IntegrationController(
         authentication: Authentication,
         @RequestParam(required = false) sourceApplicationId: Long?,
     ): Collection<IntegrationDto> {
-        return listAuthorizedIntegrations(authentication, sourceApplicationId)
+        val sourceApplicationIds = resolveAuthorizedSourceApplicationIds(authentication, sourceApplicationId)
+        return integrationService.findAllBySourceApplicationIds(sourceApplicationIds)
     }
 
     @GetMapping(params = ["side", "antall", "sorteringFelt", "sorteringRetning"])
-    fun listIntegrationsPage(
+    fun listIntegrationsPaginated(
         authentication: Authentication,
         @RequestParam(name = "side") page: Int,
         @RequestParam(name = "antall") size: Int,
         @RequestParam(name = "sorteringFelt") sortProperty: String,
         @RequestParam(name = "sorteringRetning") sortDirection: Sort.Direction,
         @RequestParam(required = false) sourceApplicationId: Long?,
-    ): Page<IntegrationDto> {
+    ): IntegrationPageResponse {
+        val sourceApplicationIds = resolveAuthorizedSourceApplicationIds(authentication, sourceApplicationId)
         val pageRequest = PageRequest.of(page, size).withSort(sortDirection, sortProperty)
-        return listAuthorizedIntegrationsPage(authentication, pageRequest, sourceApplicationId)
+        val integrations = integrationService.findAllBySourceApplicationIds(sourceApplicationIds, pageRequest)
+        return IntegrationPageResponse(
+            content = integrations.content,
+            totalElements = integrations.totalElements,
+            totalPages = integrations.totalPages,
+        )
     }
 
     @GetMapping("{integrationId}")
@@ -113,41 +119,22 @@ class IntegrationController(
         return integrationService.updateById(integrationId, integrationPatchDto)
     }
 
-    private fun listAuthorizedIntegrations(
+    private fun resolveAuthorizedSourceApplicationIds(
         authentication: Authentication,
         sourceApplicationId: Long?,
-    ): Collection<IntegrationDto> {
-        val sourceApplicationIds =
+    ): Set<Long> {
+        val authorizedSourceApplicationIds =
             userAuthorizationService.getUserAuthorizedSourceApplicationIds(authentication)
 
-        if (sourceApplicationId != null) {
-            if (!sourceApplicationIds.contains(sourceApplicationId)) {
-                throw ForbiddenWithoutBodyException()
-            }
-
-            return integrationService.findAllBySourceApplicationIds(setOf(sourceApplicationId))
+        if (sourceApplicationId == null) {
+            return authorizedSourceApplicationIds
         }
 
-        return integrationService.findAllBySourceApplicationIds(sourceApplicationIds)
-    }
-
-    private fun listAuthorizedIntegrationsPage(
-        authentication: Authentication,
-        pageable: Pageable,
-        sourceApplicationId: Long?,
-    ): Page<IntegrationDto> {
-        val sourceApplicationIds =
-            userAuthorizationService.getUserAuthorizedSourceApplicationIds(authentication)
-
-        if (sourceApplicationId != null) {
-            if (!sourceApplicationIds.contains(sourceApplicationId)) {
-                throw ForbiddenWithoutBodyException()
-            }
-
-            return integrationService.findAllBySourceApplicationIds(setOf(sourceApplicationId), pageable)
+        if (!authorizedSourceApplicationIds.contains(sourceApplicationId)) {
+            throw ForbiddenWithoutBodyException()
         }
 
-        return integrationService.findAllBySourceApplicationIds(sourceApplicationIds, pageable)
+        return setOf(sourceApplicationId)
     }
 
     private fun ensureIntegrationDoesNotAlreadyExist(integrationPostDto: IntegrationPostDto) {

--- a/src/main/kotlin/no/novari/flyt/integration/api/dto/IntegrationPageResponse.kt
+++ b/src/main/kotlin/no/novari/flyt/integration/api/dto/IntegrationPageResponse.kt
@@ -1,0 +1,7 @@
+package no.novari.flyt.integration.api.dto
+
+data class IntegrationPageResponse(
+    val content: List<IntegrationDto>,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/src/main/kotlin/no/novari/flyt/integration/web/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/no/novari/flyt/integration/web/GlobalExceptionHandler.kt
@@ -4,9 +4,11 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.integration.validation.ValidationErrorsFormattingService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
+import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.server.ResponseStatusException
 
 @ControllerAdvice
@@ -42,6 +44,33 @@ class GlobalExceptionHandler(
         return ProblemDetail.forStatusAndDetail(
             HttpStatus.UNPROCESSABLE_ENTITY,
             validationErrorMessage,
+        )
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleHttpMessageNotReadableException(exception: HttpMessageNotReadableException): ProblemDetail {
+        logger.atWarn {
+            message = "Handled malformed request body"
+            cause = exception
+        }
+
+        return ProblemDetail.forStatusAndDetail(
+            HttpStatus.BAD_REQUEST,
+            "Malformed request body",
+        )
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleMethodArgumentTypeMismatchException(exception: MethodArgumentTypeMismatchException): ProblemDetail {
+        logger.atWarn {
+            message = "Handled type mismatch for request parameter {}"
+            arguments = arrayOf(exception.name)
+            cause = exception
+        }
+
+        return ProblemDetail.forStatusAndDetail(
+            HttpStatus.BAD_REQUEST,
+            "Invalid value for request parameter '${exception.name}'",
         )
     }
 

--- a/src/test/kotlin/no/novari/flyt/integration/api/IntegrationControllerTest.kt
+++ b/src/test/kotlin/no/novari/flyt/integration/api/IntegrationControllerTest.kt
@@ -18,9 +18,14 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.security.core.Authentication
 
 @ExtendWith(MockitoExtension::class)
@@ -81,6 +86,39 @@ class IntegrationControllerTest {
         assertTrue(response.containsAll(expectedIntegrations))
         verify(integrationService).findAllBySourceApplicationIds(authorizedSourceApplicationIds)
         verify(integrationService, never()).findAll()
+    }
+
+    @Test
+    fun shouldReturnPaginatedIntegrationsWithTotals() {
+        val authorizedSourceApplicationIds = setOf(1L, 2L)
+        val integration =
+            IntegrationDto(
+                id = 1L,
+                sourceApplicationId = 1L,
+                sourceApplicationIntegrationId = "integration-1",
+                destination = "Destination 1",
+                state = Integration.State.ACTIVE,
+            )
+        val page = PageImpl(listOf(integration), PageRequest.of(0, 10), 1)
+
+        whenever(userAuthorizationService.getUserAuthorizedSourceApplicationIds(authentication))
+            .thenReturn(authorizedSourceApplicationIds)
+        whenever(integrationService.findAllBySourceApplicationIds(eq(authorizedSourceApplicationIds), any()))
+            .thenReturn(page)
+
+        val response =
+            controller.listIntegrationsPaginated(
+                authentication = authentication,
+                page = 0,
+                size = 10,
+                sortProperty = "id",
+                sortDirection = Sort.Direction.ASC,
+                sourceApplicationId = null,
+            )
+
+        assertEquals(listOf(integration), response.content)
+        assertEquals(1L, response.totalElements)
+        assertEquals(1, response.totalPages)
     }
 
     @Test

--- a/src/test/kotlin/no/novari/flyt/integration/web/GlobalExceptionHandlerMvcTest.kt
+++ b/src/test/kotlin/no/novari/flyt/integration/web/GlobalExceptionHandlerMvcTest.kt
@@ -1,0 +1,63 @@
+package no.novari.flyt.integration.web
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+class GlobalExceptionHandlerMvcTest {
+    private val mockMvc: MockMvc =
+        MockMvcBuilders
+            .standaloneSetup(ProbeController())
+            .setControllerAdvice(GlobalExceptionHandler(mock()))
+            .build()
+
+    @Test
+    fun `malformed request body returns 400 problem detail`() {
+        mockMvc
+            .perform(
+                post("/probe/body")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{ not valid json"),
+            ).andExpect(status().isBadRequest)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(400))
+    }
+
+    @Test
+    fun `path variable type mismatch returns 400 problem detail`() {
+        mockMvc
+            .perform(get("/probe/not-a-number"))
+            .andExpect(status().isBadRequest)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+            .andExpect(jsonPath("$.status").value(400))
+    }
+
+    @RestController
+    private class ProbeController {
+        @PostMapping("/probe/body")
+        fun body(
+            @RequestBody dto: ProbeDto,
+        ): ProbeDto = dto
+
+        @GetMapping("/probe/{id}")
+        fun path(
+            @PathVariable id: Long,
+        ): Long = id
+    }
+
+    private data class ProbeDto(
+        val name: String,
+    )
+}


### PR DESCRIPTION
## Sammendrag
- Erstatter `Page<IntegrationDto>` i det paginerte endepunktet med en stabil DTO `IntegrationPageResponse` (`content`, `totalElements`, `totalPages` – feltene frontend leser). Fjerner ustabil `PageImpl`-serialisering; feltnavn bevart → frontend upåvirket.
- Rydder i kontroller-navngiving: `listIntegrationsPage` → `listIntegrationsPaginated`, og de to responsformede private metodene (`listAuthorizedIntegrations`/`...Page`) er erstattet av én intensjons-navngitt `resolveAuthorizedSourceApplicationIds`.
- `GlobalExceptionHandler`: legger til håndtering av `HttpMessageNotReadableException` (malformet body) og `MethodArgumentTypeMismatchException` (feil param-type) → 400 ProblemDetail. Begge ga tidligere 500 via catch-all. Verifisert med rød→grønn probe-test.