### PR TITLE
FFS-2233 Roll out OpenTelemetry tracing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,8 @@ dependencies {
     implementation("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("org.postgresql:postgresql")
 
-    implementation("no.novari:flyt-web-resource-server:4.0.0")
+    implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
+    implementation("no.novari:telemetry-starter:0.0.4")
     implementation("no.novari:flyt-audit-starter:1.1.0")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/afk-no"
       - op: replace

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/afk-no"
       - op: replace
@@ -58,6 +63,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/afk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/agderfk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/agderfk-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/agderfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/bfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/bfk-no"
       - op: replace
@@ -58,6 +63,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/bfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 
 labels:
   - pairs:
-      app.kubernetes.io/instance: fint-flyt-integration-service_bym-oslo-kommune-no
+      app.kubernetes.io/instance: fint-flyt-integration-service_bym_oslo_kommune_no
       fintlabs.no/org-id: bym.oslo.kommune.no
 
 patches:
@@ -30,7 +30,7 @@ patches:
           name: "novari.flyt.web-resource-server.security.api.internal.authorized-org-id-role-pairs-json"
           value: |
             {
-              "bym-oslo-kommune.no":["USER"],
+              "bym.oslo.kommune.no":["USER"],
               "vigo.no":["DEVELOPER","USER"],
               "novari.no":["DEVELOPER","USER"]
             }
@@ -39,6 +39,11 @@ patches:
         value:
          name: "novari.kafka.topic.orgId"
          value: "bym-oslo-kommune-no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "novari.telemetry.org-id"
+         value: "bym.oslo.kommune.no"
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 
 labels:
   - pairs:
-      app.kubernetes.io/instance: fint-flyt-integration-service_bym_oslo_kommune_no
+      app.kubernetes.io/instance: fint-flyt-integration-service_bym-oslo-kommune-no
       fintlabs.no/org-id: bym.oslo.kommune.no
 
 patches:
@@ -30,7 +30,7 @@ patches:
           name: "novari.flyt.web-resource-server.security.api.internal.authorized-org-id-role-pairs-json"
           value: |
             {
-              "bym.oslo.kommune.no":["USER"],
+              "bym-oslo-kommune.no":["USER"],
               "vigo.no":["DEVELOPER","USER"],
               "novari.no":["DEVELOPER","USER"]
             }

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ffk-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/ffk-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/ffk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "fintlabs.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/fintlabs-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/fintlabs-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/innlandetfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/innlandetfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "mrfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/mrfylke-no"
       - op: replace

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "nfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/nfk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/ofk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -44,6 +44,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/ofk-no"
       - op: replace
@@ -58,6 +63,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/ofk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/rogfk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/rogfk-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/rogfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/telemarkfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/telemarkfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/tromsfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/tromsfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/trondelagfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/trondelagfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/vestfoldfylke-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/vestfoldfylke-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/vlfk-no"
       - op: replace

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "/beta/vlfk-no"
       - op: replace
@@ -56,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/vlfk-no/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
 
     target:
       kind: Application

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -37,6 +37,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+         name: "novari.telemetry.org-id"
+         value: "$ORG_ID"
+      - op: add
+        path: "/spec/env/-"
+        value:
          name: "server.servlet.context-path"
          value: "$SERVLET_CONTEXT_PATH"
       - op: replace
@@ -50,7 +55,7 @@ patches:
         value: "$LIVENESS_PATH"
       - op: replace
         path: "/spec/observability/metrics/path"
-        value: "$METRICS_PATH"
+        value: "$METRICS_PATH"$OTEL_EXPORTER_OTLP_ENDPOINT_PATCH
 
     target:
       kind: Application

--- a/script/render-overlay.sh
+++ b/script/render-overlay.sh
@@ -58,6 +58,19 @@ EOF
   role_map_lines="$(printf '%s\n' "$role_map_json" | sed 's/^/          /')"
   ROLE_MAP=$'\n'"$role_map_lines"
 
+  otel_exporter_otlp_endpoint_patch=""
+  if [[ "$env_name" == "beta" ]]; then
+    otel_exporter_otlp_endpoint_patch="$(cat <<EOF
+
+      - op: add
+        path: "/spec/env/-"
+        value:
+         name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+         value: "http://alloy.flais-system.svc.cluster.local:4318"
+EOF
+)"
+  fi
+
   export NAMESPACE="$namespace"
   export ORG_ID="$org_id"
   export APP_INSTANCE="$app_instance"
@@ -71,6 +84,7 @@ EOF
   export METRICS_PATH="$metrics_path"
   export ROLE_MAP
   export FINT_KAFKA_TOPIC_ORGID="$namespace"
+  export OTEL_EXPORTER_OTLP_ENDPOINT_PATCH="$otel_exporter_otlp_endpoint_patch"
 
   tmp="$(mktemp)"
   envsubst < "$BASE_TEMPLATE" > "$tmp"

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,8 @@ server:
     include-message: always
 
 spring:
+  application:
+    name: ${fint.application-id}
   jpa:
     properties:
       javax.persistence.validation.mode: none

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,22 +1,8 @@
 <configuration scan="true">
 
-    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
-            <providers>
-                <timestamp/>
-                <logLevel/>
-                <threadName/>
-                <loggerName/>
-                <message/>
-                <arguments/>
-                <throwableClassName/>
-                <throwableMessage/>
-                <stackTrace useShortFormat="true"/>
-            </providers>
-        </encoder>
-    </appender>
+    <include resource="no/novari/telemetry/logback-json.xml"/>
 
     <root level="INFO">
-        <appender-ref ref="JSON"/>
+        <appender-ref ref="TELEMETRY_JSON"/>
     </root>
 </configuration>


### PR DESCRIPTION
## Summary

- Bump `no.novari:flyt-web-resource-server` to `4.1.0-rc-2` and add `no.novari:telemetry-starter:0.0.4`.
- Enable application identity and Kafka tracing with `spring.application.name` and `novari.kafka.tracing.enabled`.
- Switch Logback JSON output to the telemetry starter fragment so trace/span IDs are emitted as top-level fields.
- Add `novari.telemetry.org-id` to generated overlays and `OTEL_EXPORTER_OTLP_ENDPOINT` only for beta overlays.

## Context

Jira: https://novari-iks.atlassian.net/browse/FFS-2233

This follows the FFS-2196 OpenTelemetry rollout pattern for HTTP and Kafka tracing across FLYT services.